### PR TITLE
Feat: add vm.etch capability

### DIFF
--- a/src/Hevm.sol
+++ b/src/Hevm.sol
@@ -46,6 +46,9 @@ interface IHevm {
 
     // Labels the address in traces
     function label(address addr, string calldata label) external;
+
+    /// Sets an address' code.
+    function etch(address target, bytes calldata newRuntimeBytecode) external;
 }
 
 IHevm constant vm = IHevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);


### PR DESCRIPTION
Tested locally.

There are a few others that can be added, but I haven't had the time to test those yet. 

`vm.etch` is a useful cheatcode.

See the medusa hevm here: https://github.com/crytic/medusa/blob/921a58f1f5155365ab6fd5c5a851d6a2595d05ab/chain/standard_cheat_code_contract.go#L188-L196