### PR TITLE
feat: add start/stopPrank to IHEVM

### DIFF
--- a/src/Hevm.sol
+++ b/src/Hevm.sol
@@ -35,6 +35,13 @@ interface IHevm {
     // Performs the next smart contract call with specified `msg.sender`
     function prank(address newSender) external;
 
+    // Sets msg.sender to the specified sender until stopPrank() is called
+    // NOTE: not currently supported by Medusa
+    function startPrank(address sender) external;
+
+    // Resets msg.sender to the default sender
+    function stopPrank() external;
+
     // Creates a new fork with the given endpoint and the latest block and returns the identifier of the fork
     function createFork(string calldata urlOrAlias) external returns (uint256);
 


### PR DESCRIPTION
This PR adds support for the `startPrank` and `stopPrank` cheatcodes which are now supported by [HEVM](https://hevm.dev/std-test-tutorial.html). 

These aren't currently supported by Medusa and a note has been made in the interface to alert users to this. The lack of support doesn't cause Medusa to throw with the "unsupported cheatcode" error so it shouldn't effect any existing setups that upgrade to use the latest version.